### PR TITLE
Fix flicker when opening HUD

### DIFF
--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -153,6 +153,7 @@ def get_menu(menuKeys):
                                  '-levenshtein-sort',
                                  '-line-padding', '2',
                                  '-kb-cancel', 'Escape,' + shortcut,
+                                 '-sync', # withhold display until menu entries are ready
                                  '-monitor', '-2', # show in the current application
                                  '-color-enabled',
                                  '-color-window', bg_color +", " + borders + ", " + borders,


### PR DESCRIPTION
Force `rofi` mode to first read all data before showing selection window. This prevents a perceivable flicker when displaying the HUD, as it forces it to display in a fully rendered state.