### PR TITLE
Add support for HiDPI displays

### DIFF
--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -153,10 +153,25 @@ def get_menu(menuKeys):
     keyval, modifiers = Gtk.accelerator_parse(shortcut)
     shortcut = '' if modifiers else ',' + shortcut
 
+    # Calculate display DPI value
+    screen = window.get_screen()
+    scale = window.get_scale_factor()
+
+    def get_dpi(pixels, mm):
+       if mm >= 1:
+          return scale * pixels / (mm / 25.4)
+       else:
+          return 0
+
+    width_dpi = get_dpi(screen.width(), screen.width_mm())
+    height_dpi = get_dpi(screen.height(), screen.height_mm())
+    dpi = scale * (width_dpi + height_dpi) / 2
+
     menu_cmd = subprocess.Popen(['rofi', '-dmenu', '-i',
                                  '-location', '1',
                                  '-width', '100', '-p', 'HUD: ',
                                  '-lines', '10', '-font', font_name,
+                                 '-dpi', str(dpi),
                                  '-separator-style', 'none',
                                  '-hide-scrollbar',
                                  '-click-to-exit',


### PR DESCRIPTION
When setting `GDK_SCALE=2` and `GDK_DPI_SCALE=0.5` as env variables, mate-hud will calculate the correct DPI value and send it off to rofi, which then scales the HUD.

This is part of multiple pull requests:
* mate-desktop/mate-settings-daemon/pull/208
* mate-desktop/mate-control-center/pull/325
* mate-desktop/mate-panel/pull/710
* ubuntu-mate/mate-hud/pull/18
* ubuntu-mate/mate-tweak/pull/37