### PR TITLE
Guard against missing event attributes

### DIFF
--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -593,8 +593,6 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         tap_start = 0
         while self.running:
             event = self.display.next_event()
-            if not hasattr(event, 'time'):
-               event.time = 0
 
             if self.modifiers:
                 # Use simpler logic when using traditional combined keybindings
@@ -610,7 +608,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
 
                # KeyPress, determine if it's the begining of the tap
                if event.type == X.KeyPress and event.detail == self.keycode and not possible_tap:
-                   tap_start = event.time
+                   tap_start = event.time if hasattr(event, 'time') else 0
                    modifiers = event.state & self.known_modifiers_mask
                    if modifiers == self.modifiers:
                        possible_tap = True
@@ -639,7 +637,7 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
                else:
                    # Replay event if the display supports it as a window-based binding
                    # otherwise send it asynchronously to let the top-level window grab it
-                   if event.detail in self.keycodes:
+                   if hasattr(event, 'detail') and event.detail in self.keycodes:
                        self.display.allow_events(X.ReplayKeyboard, X.CurrentTime)
                    else:
                        self.display.allow_events(X.AsyncKeyboard, X.CurrentTime)


### PR DESCRIPTION
@flexiondotorg - it seems as though HUD is managing to capture some non-keyboard events that don't have `'time'` or `'detail'` attributes in the XEvent object, thus causing input locks... this patch guards against `AttributeError` exceptions:

```bash
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/Xlib/protocol/rq.py", line 1294, in __getattr__
    return self._data[attr]
KeyError: 'detail'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "./usr/lib/mate-hud/mate-hud", line 647, in run
    if event.detail in self.keycodes:
  File "/usr/lib/python3/dist-packages/Xlib/protocol/rq.py", line 1298, in __getattr__
    raise AttributeError(attr)
AttributeError: detail
```
:crossed_fingers: 