### PR TITLE
Add <Alt>BackSpace to mate-hud whitelist

### DIFF
--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -508,7 +508,8 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         # White-list shortcuts used by other MATE programs
         # <Alt>Return opens up file properties
         # <Alt>Up|Left|Right|Home are navigation shortcuts in Caja
-        whitelist = ['Return', 'Up', 'Down', 'Left', 'Right', 'Home']
+        # <Alt>BackSpace is a common shortcut in text editors
+        whitelist = ['Return', 'Up', 'Down', 'Left', 'Right', 'Home', 'BackSpace']
         for key in whitelist:
             sym = Gtk.accelerator_parse(key).accelerator_key
             code = self.display.keysym_to_keycode(sym)


### PR DESCRIPTION
Hi,

As a long-term user of the Unity desktop, I just switched to Ubuntu MATE. So far, I've been loving it but this minor HUD issue has been bugging me. I don't know if this is the best way to fix the problem, but if not please let me know and I'd be happy to work on a proper fix.

Thanks,
John