### PR TITLE
Add information around compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ export UBUNTU_MENUPROXY=1
 A reference package for Debian/Ubuntu is available from:
 
   * https://bitbucket.org/flexiondotorg/debian-packages
+
+## Compatibility
+
+Compatibility may depend on your environment's compatability with the [rofi](https://github.com/davatorium/rofi/) package, which means environments using Wayland (e.g. Ubuntu 21.04) may not work (see [related rofi issue](https://github.com/davatorium/rofi/issues/446)).


### PR DESCRIPTION
add information around whether this package is compatible, notably can't get rofi to reliably work with keyboard input on wayland (ubuntu 21.04 default) thus this package may not be compatible for those in similar situations.