### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ shortcut by default.
 
 `mate-hud.py` reads one gsettings keys:
 
-  * `org.mate.hud`: `shortcut` (Default: <Super>Alt_L)
+  * `org.mate.hud`: `shortcut` (Default: `'Alt_L'`)
 
 `mate-hud.py` will not execute until those gsettings keys are created,
 which the `mate-hud` Debian package will do, and the `enabled` key


### PR DESCRIPTION
code-quote the default keybinding, <super> mention wasn't appearing in rendered markdown