### PR TITLE
Make rofi theme configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,26 @@ shortcut by default.
 
 ### Gsettings
 
-`mate-hud.py` reads one gsettings keys:
+`mate-hud.py` reads two gsettings keys:
 
   * `org.mate.hud`: `shortcut` (Default: `'Alt_L'`)
+  * `org.mate.hud`: `rofi-theme` (Default: `docu`)
 
 `mate-hud.py` will not execute until those gsettings keys are created,
 which the `mate-hud` Debian package will do, and the `enabled` key
 is set to *True* using something like `dconf-editor`. MATE Tweak
 will soon add the functionality the endable/disable `mate-hud`.
+
+### Themes
+
+`mate-hud.py` uses the `docu` theme by default. You can see the available
+rofi themes in `/usr/share/rofi/themes` or add your own to `~/.local/share/rofi/themes`
+Theme files are named `<theme name>.rasi` and you can change the theme using
+the following command:
+
+```
+gsettings set org.mate.hud rofi-theme <theme name>
+```
 
 ### Manual Setup
 

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -187,7 +187,7 @@ def get_menu(menuKeys):
                                  '-kb-cancel', 'Escape' + shortcut,
                                  '-sync', # withhold display until menu entries are ready
                                  '-monitor', '-2', # show in the current application
-                                 '-theme', 'docu'],
+                                 '-theme', get_rofi_theme()],
                                  stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     menu_cmd.stdin.write(menu_string.encode('utf-8'))
     menu_result = menu_cmd.communicate()[0].decode('utf8').rstrip()
@@ -652,6 +652,14 @@ def get_shortcut():
     except:
         logging.error('org.mate.hud gsettings not found. Defaulting to %s.' % shortcut)
     return shortcut
+
+def get_rofi_theme():
+    rofi_theme = 'docu'
+    try:
+        rofi_theme = get_string('org.mate.hud', None, 'rofi-theme')
+    except:
+        logging.error('org.mate.hud gsettings not found. Defaulting to %s.' % rofi_theme)
+    return rofi_theme
 
 def remove_autostart(filename):
     config_dir = GLib.get_user_config_dir()

--- a/usr/share/glib-2.0/schemas/org.mate.hud.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.mate.hud.gschema.xml
@@ -14,6 +14,14 @@
         The parser is fairly liberal and allows lower or upper case, and also abbreviations such as "<![CDATA[<Ctl>]]>" and "<![CDATA[<Ctrl>]]>".
       </description>
     </key>
+    <key type="s" name="rofi-theme">
+      <default>'docu'</default>
+      <summary>The rofi theme to use for the HUD</summary>
+      <description>
+        Mate HUD uses rofi to display the HUD. Specify the rofi theme to use here.
+        Find available themes in /usr/share/rofi/themes
+      </description>
+    </key>
     <key type="i" name="tap-timeout">
       <default>250</default>
       <summary>The timeout between key press and release to determine if the user meant to open MATE HUD</summary>


### PR DESCRIPTION
Release 22.04.0 hardcodes mate-hud to use the rofi docu theme which in my opinion makes it more difficult to use. 
This changes the default to Arc-Dark (feel free to pick whatever you want) but also makes the rofi theme configurable in gsettings.