### PR TITLE
Create new default theme to match GTK again

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ shortcut by default.
 `mate-hud.py` reads two gsettings keys:
 
   * `org.mate.hud`: `shortcut` (Default: `'Alt_L'`)
-  * `org.mate.hud`: `rofi-theme` (Default: `docu`)
+  * `org.mate.hud`: `rofi-theme` (Default: `mate-hud`)
 
 `mate-hud.py` will not execute until those gsettings keys are created,
 which the `mate-hud` Debian package will do, and the `enabled` key
@@ -47,8 +47,10 @@ will soon add the functionality the endable/disable `mate-hud`.
 
 ### Themes
 
-`mate-hud.py` uses the `docu` theme by default. You can see the available
-rofi themes in `/usr/share/rofi/themes` or add your own to `~/.local/share/rofi/themes`
+`mate-hud.py` uses the `mate-hud` theme by default.
+The included `mate-hud` and `mate-hud-rounded` themes try to use colors
+from your GTK theme. You can see the available rofi themes in
+`/usr/share/rofi/themes` or add your own to `~/.local/share/rofi/themes`
 Theme files are named `<theme name>.rasi` and you can change the theme using
 the following command:
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ data_files = [
     ('{prefix}/lib/mate-hud/'.format(prefix=sys.prefix), ['usr/lib/mate-hud/mate-hud']),
     ('{prefix}/share/mate/autostart/'.format(prefix=sys.prefix), ['usr/share/mate/autostart/mate-hud.desktop']),
     ('{prefix}/share/glib-2.0/schemas/'.format(prefix=sys.prefix), ['usr/share/glib-2.0/schemas/org.mate.hud.gschema.xml']),
+    ('{prefix}/share/rofi/themes/'.format(prefix=sys.prefix), ['usr/share/rofi/themes/mate-hud.rasi']),
+    ('{prefix}/share/rofi/themes/'.format(prefix=sys.prefix), ['usr/share/rofi/themes/mate-hud-rounded.rasi']),
 ]
 
 cmdclass = {

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -194,7 +194,7 @@ def get_menu(menuKeys):
 
     rofi_theme = get_rofi_theme()
     cmd = ['rofi', '-dmenu', '-i',
-           '-width', '100', '-p', 'HUD',
+           '-p', 'HUD',
            '-lines', '10', '-font', font_name,
            '-dpi', str(dpi),
            '-separator-style', 'none',

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -9,6 +9,7 @@ import os
 import psutil
 import setproctitle
 import subprocess
+import sys
 import time
 import threading
 from dbus.mainloop.glib import DBusGMainLoop
@@ -138,6 +139,21 @@ def terminate_appmenu_registrar():
         if process_running('appmenu-registrar') and not process_running(applet):
             kill_process('appmenu-registrar')
 
+def rgba_to_hex(color):
+   """
+   Return hexadecimal string for :class:`Gdk.RGBA` `color`.
+   """
+   return "#{0:02x}{1:02x}{2:02x}".format(
+                                    int(color.red   * 255),
+                                    int(color.green * 255),
+                                    int(color.blue  * 255))
+
+def get_color(style_context, preferred_color, fallback_color):
+    color = rgba_to_hex(style_context.lookup_color(preferred_color)[1])
+    if color == '#000000':
+        color = rgba_to_hex(style_context.lookup_color(fallback_color)[1])
+    return color
+
 def get_menu(menuKeys):
     """
     Generate menu of available menu items.
@@ -174,21 +190,58 @@ def get_menu(menuKeys):
     height_dpi = get_dpi(screen.height(), screen.height_mm())
     dpi = scale * (width_dpi + height_dpi) / 2
 
-    menu_cmd = subprocess.Popen(['rofi', '-dmenu', '-i',
-                                 '-location', '1',
-                                 '-width', '100', '-p', 'HUD',
-                                 '-lines', '10', '-font', font_name,
-                                 '-dpi', str(dpi),
-                                 '-separator-style', 'none',
-                                 '-hide-scrollbar',
-                                 '-click-to-exit',
-                                 '-levenshtein-sort',
-                                 '-line-padding', '2',
-                                 '-kb-cancel', 'Escape' + shortcut,
-                                 '-sync', # withhold display until menu entries are ready
-                                 '-monitor', '-2', # show in the current application
-                                 '-theme', get_rofi_theme()],
-                                 stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    theme_options = 'window { location: northwest;'
+
+    rofi_theme = get_rofi_theme()
+    cmd = ['rofi', '-dmenu', '-i',
+           '-width', '100', '-p', 'HUD',
+           '-lines', '10', '-font', font_name,
+           '-dpi', str(dpi),
+           '-separator-style', 'none',
+           '-hide-scrollbar',
+           '-click-to-exit',
+           '-levenshtein-sort',
+           '-line-padding', '2',
+           '-kb-cancel', 'Escape' + shortcut,
+           '-sync', # withhold display until menu entries are ready
+           '-monitor', '-2', # show in the current application
+           '-theme', rofi_theme,
+           '-theme-str', 'window { location: north west; }' ] # Override the window location to the top left of the current window
+
+    # If we use the default adaptive theme, we need to pull in some
+    # color information from the GTK theme
+    if rofi_theme == 'mate-hud' or rofi_theme == 'mate-hud-rounded' :
+        window = Gtk.Window()
+        style_context = window.get_style_context()
+
+        bg_color = get_color(style_context, 'dark_bg_color', 'theme_bg_color')
+        fg_color = get_color(style_context, 'dark_fg_color', 'theme_fg_color')
+        #borders = get_color(style_context, 'borders', 'border_color')
+
+        logging.debug('bg_color: %s', str(bg_color))
+        logging.debug('fg_color: %s', str(fg_color))
+        #logging.debug('borders: %s', str(borders))
+
+        selected_bg_color = rgba_to_hex(style_context.lookup_color('theme_selected_bg_color')[1])
+        selected_fg_color = rgba_to_hex(style_context.lookup_color('theme_selected_fg_color')[1])
+        #error_bg_color = rgba_to_hex(style_context.lookup_color('error_bg_color')[1])
+        #error_fg_color = rgba_to_hex(style_context.lookup_color('error_fg_color')[1])
+        #info_bg_color = rgba_to_hex(style_context.lookup_color('info_bg_color')[1])
+        #info_fg_color = rgba_to_hex(style_context.lookup_color('info_fg_color')[1])
+        #text_color = rgba_to_hex(style_context.lookup_color('theme_text_color')[1])
+        
+        # Overwrite some of the theme options
+        theme_options = '#listview { background-color: ' + bg_color + '; ' + \
+                        '            border-color: ' + selected_bg_color + '; }' + \
+                        '#element { text-color: ' + fg_color + '; }' + \
+                        '#element selected.normal { background-color: ' + selected_bg_color + '; ' + \
+                        '                           text-color: ' + selected_fg_color + '; }' + \
+                        '#inputbar { background-color: ' + bg_color + '; ' + \
+                        '            border-color: ' + selected_bg_color + '; ' + \
+                        '            text-color: ' + fg_color + '; }'
+        cmd += [ '-theme-str', theme_options ]
+
+    menu_cmd = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     menu_cmd.stdin.write(menu_string.encode('utf-8'))
     menu_result = menu_cmd.communicate()[0].decode('utf8').rstrip()
     menu_cmd.stdin.close()

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -195,7 +195,7 @@ def get_menu(menuKeys):
     rofi_theme = get_rofi_theme()
     cmd = ['rofi', '-dmenu', '-i',
            '-p', 'HUD',
-           '-lines', '10', '-font', font_name,
+           '-lines', '10',
            '-dpi', str(dpi),
            '-separator-style', 'none',
            '-hide-scrollbar',
@@ -232,14 +232,15 @@ def get_menu(menuKeys):
         #text_color = rgba_to_hex(style_context.lookup_color('theme_text_color')[1])
         
         # Overwrite some of the theme options
-        theme_options = '#listview { background-color: ' + bg_color + '; ' + \
-                        '            border-color: ' + selected_bg_color + '; }' + \
-                        '#element { text-color: ' + fg_color + '; }' + \
-                        '#element selected.normal { background-color: ' + selected_bg_color + '; ' + \
-                        '                           text-color: ' + selected_fg_color + '; }' + \
-                        '#inputbar { background-color: ' + bg_color + '; ' + \
+        theme_options = '* { font: "' + font_name + '"; } ' + \
+                        'listview { background-color: ' + bg_color + '; ' + \
+                        '           border-color: ' + selected_bg_color + '; } ' + \
+                        'element { text-color: ' + fg_color + '; } ' + \
+                        'element selected.normal { background-color: ' + selected_bg_color + '; ' + \
+                        '                           text-color: ' + selected_fg_color + '; } ' + \
+                        'inputbar { background-color: ' + bg_color + '; ' + \
                         '            border-color: ' + selected_bg_color + '; ' + \
-                        '            text-color: ' + fg_color + '; }'
+                        '            text-color: ' + fg_color + '; } '
         cmd += [ '-theme-str', theme_options ]
 
     menu_cmd = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -206,7 +206,8 @@ def get_menu(menuKeys):
            '-sync', # withhold display until menu entries are ready
            '-monitor', '-2', # show in the current application
            '-theme', rofi_theme,
-           '-theme-str', 'window { location: north west; }' ] # Override the window location to the top left of the current window
+           '-theme-str', 'window { location: north west; ' + \
+                         '         anchor: north west; }' ] # Override the window location to the top left of the current window
 
     # If we use the default adaptive theme, we need to pull in some
     # color information from the GTK theme

--- a/usr/share/glib-2.0/schemas/org.mate.hud.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.mate.hud.gschema.xml
@@ -15,11 +15,12 @@
       </description>
     </key>
     <key type="s" name="rofi-theme">
-      <default>'docu'</default>
+      <default>'mate-hud'</default>
       <summary>The rofi theme to use for the HUD</summary>
       <description>
         Mate HUD uses rofi to display the HUD. Specify the rofi theme to use here.
-        Find available themes in /usr/share/rofi/themes
+        'mate-hud' and 'mate-hud-rounded' try to pull colors from the GTK theme.
+        Find available themes in /usr/share/rofi/themes or put your own in ~/.local/share/rofi/themes
       </description>
     </key>
     <key type="i" name="tap-timeout">

--- a/usr/share/rofi/themes/mate-hud-rounded.rasi
+++ b/usr/share/rofi/themes/mate-hud-rounded.rasi
@@ -8,7 +8,6 @@
 configuration {
 
 	font: "Sans Regular 10";
-	width: 400px;
 	line-margin: 10;
 	lines: 6;
 	columns: 2;
@@ -29,6 +28,7 @@ configuration {
 window {
     location: north west;
     anchor:   north west;
+	width: 400px;
     transparency: "screenshot";
     //padding: 10px;
     border:  0px;

--- a/usr/share/rofi/themes/mate-hud-rounded.rasi
+++ b/usr/share/rofi/themes/mate-hud-rounded.rasi
@@ -69,7 +69,7 @@ prompt {
 }
 
 listview {
-    padding: 8px 0px;
+    padding: 8px;
     border-radius: 0px 0px 6px 6px;
     /* border-color: matched to GTK theme by mate-hud */
     border: 0px 1px 1px 1px;

--- a/usr/share/rofi/themes/mate-hud-rounded.rasi
+++ b/usr/share/rofi/themes/mate-hud-rounded.rasi
@@ -8,7 +8,7 @@
 configuration {
 
 	font: "Sans Regular 10";
-	width: 30;
+	width: 400px;
 	line-margin: 10;
 	lines: 6;
 	columns: 2;

--- a/usr/share/rofi/themes/mate-hud-rounded.rasi
+++ b/usr/share/rofi/themes/mate-hud-rounded.rasi
@@ -1,0 +1,97 @@
+/**
+ * Mate-hud-rounded rofi theme (rounded corners)
+ * Incomplete theme designed to have certain properties applied at mate-hud runtime
+ * Don't use this for anything else than mate-hud
+ * Adapted by twa022 <twa022 at gmail dot com>
+ */
+
+configuration {
+
+	font: "Sans Regular 10";
+	width: 30;
+	line-margin: 10;
+	lines: 6;
+	columns: 2;
+
+    display-ssh:    "";
+    display-run:    "";
+    display-drun:   "";
+    display-window: "";
+    display-combi:  "";
+    show-icons:     true;
+}
+
+* {
+    backlight:   #ccffeedd;
+    background-color:  transparent;
+}
+
+window {
+    location: north west;
+    anchor:   north west;
+    transparency: "screenshot";
+    //padding: 10px;
+    border:  0px;
+    border-radius: 6px;
+
+    /* background-color: matched to GTK theme by mate-hud */
+    spacing: 0;
+    children:  [mainbox];
+    orientation: horizontal;
+
+    margin: 33px 5px;
+
+   font: "Sans Regular 10";
+}
+
+mainbox {
+    spacing: 0;
+    children: [ inputbar, message, listview ];
+}
+
+inputbar {
+    /* text-color: matched to GTK theme by mate-hud */
+    padding: 11px;
+    /* background-color: matched to GTK theme by mate-hud */
+
+    border: 1px;
+    border-radius:  6px 6px 0px 0px;
+    /* border-color: matched to GTK theme by mate-hud */
+}
+
+entry, prompt, case-indicator {
+    text-font: inherit;
+    text-color:inherit;
+}
+
+prompt {
+    margin: 0px 0.3em 0em 0em ;
+}
+
+listview {
+    padding: 8px 0px;
+    border-radius: 0px 0px 6px 6px;
+    /* border-color: matched to GTK theme by mate-hud */
+    border: 0px 1px 1px 1px;
+    /* background-color: matched to GTK theme by mate-hud */
+    dynamic: false;
+    font: "Sans Regular 10";
+}
+
+element {
+    padding: 3px;
+    vertical-align: 0.5;
+    border-radius: 4px;
+    background-color: transparent;
+    /* text-color: matched to GTK theme by mate-hud */
+}
+
+element selected.normal {
+	/* background-color: matched to GTK theme by mate-hud */
+	/* text-color: matched to GTK theme by mate-hud */
+}
+
+element-text, element-icon {
+    background-color: inherit;
+    text-color:       inherit;
+}

--- a/usr/share/rofi/themes/mate-hud-rounded.rasi
+++ b/usr/share/rofi/themes/mate-hud-rounded.rasi
@@ -7,10 +7,10 @@
 
 configuration {
 
-	font: "Sans Regular 10";
-	line-margin: 10;
-	lines: 6;
-	columns: 2;
+    font: "Sans Regular 10";
+    line-margin: 10;
+    lines: 6;
+    columns: 2;
 
     display-ssh:    "";
     display-run:    "";
@@ -28,7 +28,7 @@ configuration {
 window {
     location: north west;
     anchor:   north west;
-	width: 400px;
+    width: 400px;
     transparency: "screenshot";
     //padding: 10px;
     border:  0px;
@@ -39,9 +39,9 @@ window {
     children:  [mainbox];
     orientation: horizontal;
 
-    margin: 33px 5px;
+    // margin: 33px 5px;
 
-   font: "Sans Regular 10";
+    font: "Sans Regular 10";
 }
 
 mainbox {
@@ -87,8 +87,8 @@ element {
 }
 
 element selected.normal {
-	/* background-color: matched to GTK theme by mate-hud */
-	/* text-color: matched to GTK theme by mate-hud */
+    /* background-color: matched to GTK theme by mate-hud */
+    /* text-color: matched to GTK theme by mate-hud */
 }
 
 element-text, element-icon {

--- a/usr/share/rofi/themes/mate-hud.rasi
+++ b/usr/share/rofi/themes/mate-hud.rasi
@@ -8,7 +8,6 @@
 configuration {
 
 	font: "Sans Regular 10";
-	width: 400px;
 	line-margin: 10;
 	lines: 6;
 	columns: 2;
@@ -29,6 +28,7 @@ configuration {
 window {
     location: north west;
     anchor:   north west;
+	width: 400px;
     transparency: "screenshot";
     //padding: 10px;
     border:  0px;

--- a/usr/share/rofi/themes/mate-hud.rasi
+++ b/usr/share/rofi/themes/mate-hud.rasi
@@ -8,7 +8,7 @@
 configuration {
 
 	font: "Sans Regular 10";
-	width: 30;
+	width: 400px;
 	line-margin: 10;
 	lines: 6;
 	columns: 2;

--- a/usr/share/rofi/themes/mate-hud.rasi
+++ b/usr/share/rofi/themes/mate-hud.rasi
@@ -7,10 +7,10 @@
 
 configuration {
 
-	font: "Sans Regular 10";
-	line-margin: 10;
-	lines: 6;
-	columns: 2;
+    font: "Sans Regular 10";
+    line-margin: 10;
+    lines: 6;
+    columns: 2;
 
     display-ssh:    "";
     display-run:    "";
@@ -28,7 +28,7 @@ configuration {
 window {
     location: north west;
     anchor:   north west;
-	width: 400px;
+    width: 400px;
     transparency: "screenshot";
     //padding: 10px;
     border:  0px;
@@ -39,9 +39,9 @@ window {
     children:  [mainbox];
     orientation: horizontal;
 
-    margin: 33px 5px;
+    // margin: 33px 5px;
 
-   font: "Sans Regular 10";
+    font: "Sans Regular 10";
 }
 
 mainbox {
@@ -87,8 +87,8 @@ element {
 }
 
 element selected.normal {
-	/* background-color: matched to GTK theme by mate-hud */
-	/* text-color: matched to GTK theme by mate-hud */
+    /* background-color: matched to GTK theme by mate-hud */
+    /* text-color: matched to GTK theme by mate-hud */
 }
 
 element-text, element-icon {

--- a/usr/share/rofi/themes/mate-hud.rasi
+++ b/usr/share/rofi/themes/mate-hud.rasi
@@ -1,0 +1,97 @@
+/**
+ * Mate-hud rofi theme
+ * Incomplete theme designed to have certain properties applied at mate-hud runtime
+ * Don't use this for anything else than mate-hud
+ * Adapted by twa022 <twa022 at gmail dot com>
+ */
+
+configuration {
+
+	font: "Sans Regular 10";
+	width: 30;
+	line-margin: 10;
+	lines: 6;
+	columns: 2;
+
+    display-ssh:    "";
+    display-run:    "";
+    display-drun:   "";
+    display-window: "";
+    display-combi:  "";
+    show-icons:     true;
+}
+
+* {
+    backlight:   #ccffeedd;
+    background-color:  transparent;
+}
+
+window {
+    location: north west;
+    anchor:   north west;
+    transparency: "screenshot";
+    //padding: 10px;
+    border:  0px;
+    //border-radius: 6px;
+
+    /* background-color: matched to GTK theme by mate-hud */
+    spacing: 0;
+    children:  [mainbox];
+    orientation: horizontal;
+
+    margin: 33px 5px;
+
+   font: "Sans Regular 10";
+}
+
+mainbox {
+    spacing: 0;
+    children: [ inputbar, message, listview ];
+}
+
+inputbar {
+    /* text-color: matched to GTK theme by mate-hud */
+    padding: 11px;
+    /* background-color: matched to GTK theme by mate-hud */
+
+    border: 1px;
+    //border-radius:  6px 6px 0px 0px;
+    /* border-color: matched to GTK theme by mate-hud */
+}
+
+entry, prompt, case-indicator {
+    text-font: inherit;
+    text-color:inherit;
+}
+
+prompt {
+    margin: 0px 0.3em 0em 0em ;
+}
+
+listview {
+    padding: 8px 0px;
+    //border-radius: 0px 0px 6px 6px;
+    /* border-color: matched to GTK theme by mate-hud */
+    border: 0px 1px 1px 1px;
+    /* background-color: matched to GTK theme by mate-hud */
+    dynamic: false;
+    font: "Sans Regular 10";
+}
+
+element {
+    padding: 3px 0px;
+    vertical-align: 0.5;
+    //border-radius: 4px;
+    background-color: transparent;
+    /* text-color: matched to GTK theme by mate-hud */
+}
+
+element selected.normal {
+	/* background-color: matched to GTK theme by mate-hud */
+	/* text-color: matched to GTK theme by mate-hud */
+}
+
+element-text, element-icon {
+    background-color: inherit;
+    text-color:       inherit;
+}

--- a/usr/share/rofi/themes/mate-hud.rasi
+++ b/usr/share/rofi/themes/mate-hud.rasi
@@ -69,7 +69,7 @@ prompt {
 }
 
 listview {
-    padding: 8px 0px;
+    padding: 8px;
     //border-radius: 0px 0px 6px 6px;
     /* border-color: matched to GTK theme by mate-hud */
     border: 0px 1px 1px 1px;


### PR DESCRIPTION
This creates a new default theme that tries to dynamically match the GTK theme (as was done in versions before 22.04.0) but using a new method of overriding values in the provided `mate-hud` rofi theme.
The theme is still configurable through the `org.mate.hud.rofi-theme` gsettings key. Only when `mate-hud` or `mate-hud-rounded` are selected does the program attempt to do any theme color matching. If another theme is selected it leaves it be.

A couple more things I think could be implemented, let me know what you think:

- The program currently overrides the theme to position the HUD at the top left (north west) corner of the current window). For people using RTL languages should it override it to the top right (north east)? Is there a better was to check that than comparing  `LANG` environment variable to a list of known RTL locales?
- Include an option to anchor the hud to the screen rather than the window? Wasn't that the default Unity implementation? I use an appmenu plugin in the top panel and think it kind of makes sense to show the HUD below that (or at least provide the option).