### PR TITLE
Add some support for other desktop environments (mostly XFCE)

### DIFF
--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -140,7 +140,7 @@ def terminate_appmenu_registrar():
     #  - Use Dbus Quit method.
     #  - Add checks for other Desktop Environments.
     if 'MATE' in os.environ['XDG_CURRENT_DESKTOP']:
-        if process_running('appmenu-registrar') and not process_running('applet-mate'):
+        if process_running('appmenu-registrar') and not process_running('appmenu-mate'):
             kill_process('appmenu-registrar')
     elif process_running('xfce4-panel'):
         try:

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -139,11 +139,10 @@ def terminate_appmenu_registrar():
     # TODO:
     #  - Use Dbus Quit method.
     #  - Add checks for other Desktop Environments.
-    desktop_name = os.environ['XDG_CURRENT_DESKTOP']
-    if 'MATE' in desktop_name:
+    if 'MATE' in os.environ['XDG_CURRENT_DESKTOP']:
         if process_running('appmenu-registrar') and not process_running('applet-mate'):
             kill_process('appmenu-registrar')
-    elif 'XFCE' in desktop_name:
+    elif process_running('xfce4-panel'):
         try:
             xfc_panel = Xfconf.Channel.new("xfce4-panel")
             panels = xfc_panel.get_arrayv("/panels")
@@ -158,7 +157,7 @@ def terminate_appmenu_registrar():
             if process_running('appmenu-registrar') and not appmenu_loaded:
                 kill_process('appmenu-registrar')
         except:
-            logging.debug('running XFCE, but xfconf gi repository not available')
+            logging.debug('running XFCE panel, but xfconf gi repository not available')
 
 def rgba_to_hex(color):
    """

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -197,6 +197,15 @@ def get_menu(menuKeys):
     height_dpi = get_dpi(screen.height(), screen.height_mm())
     dpi = scale * (width_dpi + height_dpi) / 2
 
+    if 'XFCE' in desktop_name:
+        xfce_custom_dpi = 0
+        try:
+            xfce_custom_dpi = Xfconf.Channel.new_with_property_base("xsettings", "/Xft").get_int("/DPI", 0)
+        except:
+            logging.debug('running XFCE, but xfconf gi repository not available')
+        if xfce_custom_dpi > 0:
+            dpi = xfce_custom_dpi
+
     rofi_theme = get_rofi_theme()
     cmd = ['rofi', '-dmenu', '-i',
            '-p', 'HUD',

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -139,13 +139,26 @@ def terminate_appmenu_registrar():
     # TODO:
     #  - Use Dbus Quit method.
     #  - Add checks for other Desktop Environments.
-    applet = None
-    if 'MATE' in os.environ['XDG_CURRENT_DESKTOP']:
-        applet = 'appmenu-mate'
-
-    if applet:
-        if process_running('appmenu-registrar') and not process_running(applet):
+    desktop_name = os.environ['XDG_CURRENT_DESKTOP']
+    if 'MATE' in desktop_name:
+        if process_running('appmenu-registrar') and not process_running('applet-mate'):
             kill_process('appmenu-registrar')
+    elif 'XFCE' in desktop_name:
+        try:
+            xfc_panel = Xfconf.Channel.new("xfce4-panel")
+            panels = xfc_panel.get_arrayv("/panels")
+            plugin_ids = []
+            for panel in panels:
+                plugin_ids += xfc_panel.get_arrayv("/panels/panel-" + str(panel) + "/plugin-ids")
+            appmenu_loaded = False
+            for plugid in plugin_ids:
+                if ( xfc_panel.get_string("/plugins/plugin-" + str(plugid), "") == 'appmenu' ):
+                    appmenu_loaded = True
+                    break
+            if process_running('appmenu-registrar') and not appmenu_loaded:
+                kill_process('appmenu-registrar')
+        except:
+            logging.debug('running XFCE, but xfconf gi repository not available')
 
 def rgba_to_hex(color):
    """

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -16,7 +16,7 @@ from dbus.mainloop.glib import DBusGMainLoop
 from gi.repository import Gio, GLib, Gtk, Gdk, GObject
 from Xlib import display, protocol, X, Xatom, error
 
-if 'XFCE' in os.getenv('XDG_CURRENT_DESKTOP'):
+if 'XFCE' in os.environ['XDG_CURRENT_DESKTOP']:
     try:
         gi.require_version("Xfconf", "0")
         from gi.repository import Xfconf
@@ -194,7 +194,7 @@ def get_menu(menuKeys):
     keyval, modifiers = Gtk.accelerator_parse(shortcut)
     shortcut = '' if modifiers else ',' + shortcut
 
-    desktop_name = os.getenv('XDG_CURRENT_DESKTOP')
+    desktop_name = os.environ['XDG_CURRENT_DESKTOP']
 
     # Calculate display DPI value
     screen = window.get_screen()

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -16,6 +16,14 @@ from dbus.mainloop.glib import DBusGMainLoop
 from gi.repository import Gio, GLib, Gtk, Gdk, GObject
 from Xlib import display, protocol, X, Xatom, error
 
+if 'XFCE' in os.getenv('XDG_CURRENT_DESKTOP'):
+    try:
+        gi.require_version("Xfconf", "0")
+        from gi.repository import Xfconf
+        Xfconf.init()
+    except:
+        logging.debug('running XFCE, but xfconf gi repository not available')
+
 class EWMH:
     """This class provides the ability to get and set properties defined
     by the EWMH spec. It was blanty ripped out of pyewmh
@@ -165,9 +173,6 @@ def get_menu(menuKeys):
     for menu_item in menu_items:
         menu_string += '\n' + menu_item
 
-    # Get the currently active font.
-    font_name = get_string('org.mate.interface', None, 'font-name')
-
     # Get some colors from the currently selected theme.
     window = Gtk.Window()
 
@@ -175,6 +180,8 @@ def get_menu(menuKeys):
     shortcut = get_shortcut()
     keyval, modifiers = Gtk.accelerator_parse(shortcut)
     shortcut = '' if modifiers else ',' + shortcut
+
+    desktop_name = os.getenv('XDG_CURRENT_DESKTOP')
 
     # Calculate display DPI value
     screen = window.get_screen()
@@ -189,8 +196,6 @@ def get_menu(menuKeys):
     width_dpi = get_dpi(screen.width(), screen.width_mm())
     height_dpi = get_dpi(screen.height(), screen.height_mm())
     dpi = scale * (width_dpi + height_dpi) / 2
-
-    theme_options = 'window { location: northwest;'
 
     rofi_theme = get_rofi_theme()
     cmd = ['rofi', '-dmenu', '-i',
@@ -212,6 +217,22 @@ def get_menu(menuKeys):
     # If we use the default adaptive theme, we need to pull in some
     # color information from the GTK theme
     if rofi_theme == 'mate-hud' or rofi_theme == 'mate-hud-rounded' :
+        # Get the currently active font.
+        font_name = ''
+        if 'MATE' in desktop_name:
+            font_name = get_string('org.mate.interface', None, 'font-name')
+        elif 'XFCE' in desktop_name:
+            try:
+                font_name = Xfconf.Channel.new_with_property_base("xsettings", "/Gtk").get_string("/FontName", "")
+            except:
+                logging.debug('running XFCE, but xfconf gi repository not available')
+        elif 'X-Cinnamon' in desktop_name:
+            font_name = get_string('org.cinnamon.desktop.interface', None, 'font-name')
+        elif 'Budgie:GNOME' in desktop_name:
+            font_name = get_string('org.gnome.desktop.interface', None, 'font-name')
+        if font_name:
+            cmd += [ '-theme-str', '* { font: "' + font_name + '"; } ' ]
+
         window = Gtk.Window()
         style_context = window.get_style_context()
 
@@ -232,8 +253,7 @@ def get_menu(menuKeys):
         #text_color = rgba_to_hex(style_context.lookup_color('theme_text_color')[1])
         
         # Overwrite some of the theme options
-        theme_options = '* { font: "' + font_name + '"; } ' + \
-                        'listview { background-color: ' + bg_color + '; ' + \
+        theme_options = 'listview { background-color: ' + bg_color + '; ' + \
                         '           border-color: ' + selected_bg_color + '; } ' + \
                         'element { text-color: ' + fg_color + '; } ' + \
                         'element selected.normal { background-color: ' + selected_bg_color + '; ' + \

--- a/usr/lib/mate-hud/mate-hud
+++ b/usr/lib/mate-hud/mate-hud
@@ -210,7 +210,7 @@ def get_menu(menuKeys):
     cmd = ['rofi', '-dmenu', '-i',
            '-p', 'HUD',
            '-lines', '10',
-           '-dpi', str(dpi),
+           '-dpi', str(round(dpi)),
            '-separator-style', 'none',
            '-hide-scrollbar',
            '-click-to-exit',


### PR DESCRIPTION
Adds support for other desktop environments in a few places:

- font-matching - Check the desktop specific configuration for MATE, XFCE, Budgie, Cinnamon, if not found don't try to match the font but use what's in the rasi theme
- DPI - Check XFCE's custom dpi setting if running XFCE
- appmenu_registrar - add logic to check if the XFCE panel applet is running (if in XFCE) so we can shut down the registrar if not

This adds an optional dependency on gir1.2-xfconf-0 to check xfconf settings in XFCE. I don't know how *buntu packaging deals with that, but I can update the Arch package if merged/released.